### PR TITLE
Fix: Resolve conflicting imports and undefined class errors

### DIFF
--- a/lib/features/modules/module_outline_view.dart
+++ b/lib/features/modules/module_outline_view.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import '../../widgets/aelion_appbar.dart';
-import '../../core/app_colors.dart';
-import '../../services/course_api_service.dart';
-import '../../services/progress_service.dart';
-import '../quiz/quiz_screen.dart';
-import '../lesson/lesson_view.dart';
-import '../../services/api_config.dart';
+import 'package:learning_ia/core/app_colors.dart';
+import 'package:learning_ia/features/lesson/lesson_view.dart';
+import 'package:learning_ia/features/quiz/quiz_screen.dart';
+import 'package:learning_ia/services/api_config.dart';
+import 'package:learning_ia/services/course_api_service.dart';
+import 'package:learning_ia/services/progress_service.dart';
+import 'package:learning_ia/widgets/aelion_appbar.dart';
 
 class ModuleOutlineView extends StatefulWidget {
   static const routeName = '/module';

--- a/lib/services/course_api_service.dart
+++ b/lib/services/course_api_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-import 'api_config.dart';
+import 'package:learning_ia/services/api_config.dart';
 
 /// Servicio de curso – usa AppConfig. No depende de `isConfigured`.
 class CourseApiService {


### PR DESCRIPTION
Updated import statements in `module_outline_view.dart` and `course_api_service.dart` to use absolute `package:` paths instead of relative paths.

This change addresses two build errors:
- A conflicting import error for `CourseApiService`.
- An "undefined AppConfig" error.

Using absolute package imports is a best practice in Flutter and removes ambiguity in dependency resolution, which was the likely cause of the errors.