### PR TITLE
Update router to use SignInScreen for signin route

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -12,10 +12,10 @@ class AppRouter {
           builder: (_) => const AuthGate(child: HomeView()),
           settings: const RouteSettings(name: '/'),
         );
-      case LoginScreen.routeName:
+      case '/signin':
         return MaterialPageRoute(
-          builder: (_) => const LoginScreen(),
-          settings: const RouteSettings(name: LoginScreen.routeName),
+          builder: (_) => const SignInScreen(),
+          settings: const RouteSettings(name: '/signin'),
         );
       case HomeView.routeName:
         return MaterialPageRoute(
@@ -31,8 +31,8 @@ class AppRouter {
         );
       default:
         return MaterialPageRoute(
-          builder: (_) => const _NotFoundPage(),
-          settings: const RouteSettings(name: '/404'),
+          builder: (_) => const SignInScreen(),
+          settings: RouteSettings(name: settings.name ?? '/signin'),
         );
     }
   }

--- a/lib/features/auth/auth_gate.dart
+++ b/lib/features/auth/auth_gate.dart
@@ -61,7 +61,7 @@ class AuthGate extends StatelessWidget {
 
         final user = snapshot.data;
         if (user == null) {
-          return const LoginScreen();
+          return const SignInScreen();
         }
 
         return child;

--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -1,0 +1,1 @@
+export 'sign_in_screen.dart' show SignInScreen;

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -20,6 +20,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(MaterialApp), findsOneWidget);
-    expect(find.byType(LoginScreen), findsOneWidget);
+    expect(find.byType(SignInScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- route the `/signin` path and default fallback to the new `SignInScreen`
- ensure the auth gate and tests instantiate `SignInScreen` while providing a compatibility export

## Testing
- flutter test test/app_test.dart *(fails: flutter command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9a091048832cb94fa001acf544cd