### PR TITLE
Add barrel export for login screen

### DIFF
--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -1,0 +1,1 @@
+export 'sign_in_screen.dart';


### PR DESCRIPTION
## Summary
- add a login_screen barrel file that re-exports the sign in screen to satisfy existing imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9c982604832ca51cb1d79524138f