### PR TITLE
Use withValues for skeleton surface color

### DIFF
--- a/lib/widgets/skeleton.dart
+++ b/lib/widgets/skeleton.dart
@@ -18,7 +18,7 @@ class Skeleton extends StatelessWidget {
       height: height,
       width: width,
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+        color: Theme.of(context).colorScheme.surfaceVariant.withValues(alpha: 0.5),
         borderRadius: BorderRadius.all(Radius.circular(cornerRadius)),
       ),
     );


### PR DESCRIPTION
## Summary
- switch the Skeleton widget's surface color to use `withValues` to avoid the `withOpacity` deprecation warning

## Testing
- ⚠️ `flutter analyze` *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dca2418330832ca292f450a9de79d1